### PR TITLE
feat: add multi commit support

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-09-19T13:49:50Z by kres 9ea8a33.
+# Generated on 2022-09-19T19:55:11Z by kres 255fc05.
 
 ---
 policies:
@@ -29,7 +29,6 @@ policies:
     skipPaths:
       - .git/
       - testdata/
-      - internal/policy/license/
     includeSuffixes:
       - .go
     excludeSuffixes:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-09-19T13:49:50Z by kres 9ea8a33.
+# Generated on 2022-09-19T19:52:38Z by kres 255fc05.
 
 kind: pipeline
 type: kubernetes
@@ -340,6 +340,9 @@ trigger:
     exclude:
     - renovate/*
     - dependabot/*
+  status:
+  - success
+  - failure
 
 depends_on:
 - default

--- a/cmd/conform/enforce.go
+++ b/cmd/conform/enforce.go
@@ -43,6 +43,12 @@ var enforceCmd = &cobra.Command{
 			opts = append(opts, policy.WithCommitRef(commitRef))
 		}
 
+		if baseBranch := cmd.Flags().Lookup("base-branch").Value.String(); baseBranch != "" {
+			opts = append(opts, policy.WithRevisionRange(fmt.Sprintf("%s..HEAD", baseBranch)))
+		} else if revisionRange := cmd.Flags().Lookup("revision-range").Value.String(); revisionRange != "" {
+			opts = append(opts, policy.WithRevisionRange(revisionRange))
+		}
+
 		return e.Enforce(opts...)
 	},
 }
@@ -51,5 +57,7 @@ func init() {
 	enforceCmd.Flags().String("commit-msg-file", "", "the path to the temporary commit message file")
 	enforceCmd.Flags().String("commit-ref", "", "the ref to compare git policies against")
 	enforceCmd.Flags().String("reporter", "none", "the reporter method to use")
+	enforceCmd.Flags().String("revision-range", "", "<commit1>..<commit2>")
+	enforceCmd.Flags().String("base-branch", "", "base branch to compare with")
 	rootCmd.AddCommand(enforceCmd)
 }

--- a/internal/policy/license/license_test.go
+++ b/internal/policy/license/license_test.go
@@ -1,9 +1,9 @@
-//go:build !some_test_tag
-// +build !some_test_tag
-
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build !some_test_tag
+// +build !some_test_tag
 
 package license_test
 
@@ -23,7 +23,7 @@ func TestLicense(t *testing.T) {
 
 	t.Run("Default", func(t *testing.T) {
 		l := license.License{
-			IncludeSuffixes:        []string{".go"},
+			IncludeSuffixes:        []string{".txt"},
 			AllowPrecedingComments: false,
 			Header:                 header,
 		}
@@ -33,7 +33,7 @@ func TestLicense(t *testing.T) {
 
 	t.Run("AllowPrecedingComments", func(t *testing.T) {
 		l := license.License{
-			IncludeSuffixes:        []string{".go"},
+			IncludeSuffixes:        []string{".txt"},
 			AllowPrecedingComments: true,
 			Header:                 header,
 		}

--- a/internal/policy/license/testdata/data.txt
+++ b/internal/policy/license/testdata/data.txt
@@ -1,0 +1,5 @@
+//this is a preceding comment
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/internal/policy/policy_options.go
+++ b/internal/policy/policy_options.go
@@ -11,6 +11,7 @@ type Option func(*Options)
 type Options struct {
 	CommitMsgFile *string
 	CommitRef     string
+	RevisionRange string
 }
 
 // WithCommitMsgFile sets the path to the commit message file.
@@ -24,6 +25,13 @@ func WithCommitMsgFile(o *string) Option {
 func WithCommitRef(o string) Option {
 	return func(args *Options) {
 		args.CommitRef = o
+	}
+}
+
+// WithRevisionRange sets the revision range to compare git policies against.
+func WithRevisionRange(o string) Option {
+	return func(args *Options) {
+		args.RevisionRange = o
 	}
 }
 


### PR DESCRIPTION
This is a proposal that enables enforcing policies on a range of commits, which is handy in CIs when a pull request contains multiple commits.

---

Add the ability to enforce commit policies on a commit range.

Two options are available:
- --revision-range <commit1..commit2>: analyse the given git revision
  range
- --base-branch <name>: convenience for --revision-range name..HEAD

If commit1 is not an ancestor of commit2, the merge base (first common
ancestor) is used as first commit.

Signed-off-by: Vincent Dupont <vincentdup@gmail.com>