### PR TITLE
fix: bump action image v0.1.0-alpha.26-3-g6380738

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,4 +9,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://autonomy/conform:v0.1.0-alpha.20"
+  image: "docker://ghcr.io/siderolabs/conform:v0.1.0-alpha.27"
+  args:
+    - 'enforce'


### PR DESCRIPTION
This bumps the action image to latest 0.1.26.
It also adds the needed enforce arg.

Signed-off-by: Josef Andersson <josef.andersson@gmail.com>