### PR TITLE
feat: add support for multiple licenses

### DIFF
--- a/internal/policy/license/license_test.go
+++ b/internal/policy/license/license_test.go
@@ -21,23 +21,75 @@ func TestLicense(t *testing.T) {
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.`
 
+	const otherHeader = "// some-other-header"
+
 	t.Run("Default", func(t *testing.T) {
-		l := license.License{
-			IncludeSuffixes:        []string{".txt"},
-			AllowPrecedingComments: false,
-			Header:                 header,
+		l := license.Licenses{
+			{
+				SkipPaths:              []string{"subdir1/"},
+				IncludeSuffixes:        []string{".txt"},
+				AllowPrecedingComments: false,
+				Header:                 header,
+			},
 		}
-		check := l.ValidateLicenseHeader()
+		check := l.ValidateLicenseHeaders()
 		assert.Equal(t, "Found 1 files without license header", check.Message())
 	})
 
 	t.Run("AllowPrecedingComments", func(t *testing.T) {
-		l := license.License{
-			IncludeSuffixes:        []string{".txt"},
-			AllowPrecedingComments: true,
-			Header:                 header,
+		l := license.Licenses{
+			{
+				SkipPaths:              []string{"subdir1/"},
+				IncludeSuffixes:        []string{".txt"},
+				AllowPrecedingComments: true,
+				Header:                 header,
+			},
 		}
-		check := l.ValidateLicenseHeader()
+		check := l.ValidateLicenseHeaders()
 		assert.Equal(t, "All files have a valid license header", check.Message())
+	})
+
+	// File "testdata/subdir1/subdir2/data.txt" is valid for the root license, but "testdata/subdir1/" is skipped.
+	// It is invalid for the additional license, but that license skips "subdir2/" relative to itself.
+	// The check should pass.
+	t.Run("AdditionalValid", func(t *testing.T) {
+		l := license.Licenses{
+			{
+				IncludeSuffixes:        []string{".txt"},
+				SkipPaths:              []string{"testdata/subdir1/"},
+				AllowPrecedingComments: true,
+				Header:                 header,
+			},
+			{
+				Root:            "testdata/subdir1/",
+				SkipPaths:       []string{"subdir2/"},
+				IncludeSuffixes: []string{".txt"},
+				Header:          otherHeader,
+			},
+		}
+		check := l.ValidateLicenseHeaders()
+		assert.Equal(t, "All files have a valid license header", check.Message())
+	})
+
+	// File "testdata/subdir1/subdir2/data.txt" is valid for the root license, but "testdata/subdir1/" is skipped.
+	// However, it is invalid for the additional license.
+	// The check should fail.
+	t.Run("AdditionalInvalid", func(t *testing.T) {
+		l := license.Licenses{
+			{
+				IncludeSuffixes:        []string{".txt"},
+				SkipPaths:              []string{"testdata/subdir1/"},
+				AllowPrecedingComments: true,
+				Header:                 header,
+			},
+
+			{
+				Root:            "testdata/subdir1/",
+				IncludeSuffixes: []string{".txt"},
+				Header:          otherHeader,
+			},
+		}
+		check := l.ValidateLicenseHeaders()
+		assert.Equal(t, "Found 1 files without license header", check.Message())
 	})
 }

--- a/internal/policy/license/testdata/subdir1/data.txt
+++ b/internal/policy/license/testdata/subdir1/data.txt
@@ -1,0 +1,3 @@
+// some-other-header
+
+content

--- a/internal/policy/license/testdata/subdir1/subdir2/data.txt
+++ b/internal/policy/license/testdata/subdir1/subdir2/data.txt
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+content


### PR DESCRIPTION
feat: add support for multiple licenses

Allow specifying multiple policy documents of `type: commit` in `.conform.yaml`.

Join these multiple policy declarations into a single license check policy.

In the license check spec, introduce a new field, `root`, to allow specifying in which directory that license check should run.

With this change, a single repository will be able to have different license rules for different paths.

Sample conform file with the changes:
```yaml
policies:
  - type: commit
    spec: "..."
  - type: license
    spec:
      includeSuffixes:
        - .go
      excludeSuffixes:
        - .pb.go
        - .pb.gw.go
      header: "// ROOT LICENSE"
  - type: license
    spec:
      root: staging/client/
      includeSuffixes:
        - .go
      excludeSuffixes:
        - .pb.go
        - .pb.gw.go
      header: "// SUBDIR LICENSE"
```
