### PR TITLE
docs: fix container run option for selinux systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ go install github.com/siderolabs/conform/cmd/conform@latest
 Third option is to run it as a container:
 
 ```bash
-docker run --rm -it -v $PWD:/src -w /src ghcr.io/siderolabs/conform:v0.1.0-alpha.22 enforce
+docker run --rm -it -v $PWD:/src:ro,Z -w /src ghcr.io/siderolabs/conform:v0.1.0-alpha.22 enforce
 ```
 
 You can also install conform with [aqua](https://aquaproj.github.io/).


### PR DESCRIPTION
Example code to run in a container didn't work on SELinux systems.
Added filesystem labeling flag to the volume bind mount.
Change will not affect non-SELinux systems.
Also added read-only flag, since conform doesn't need write access.